### PR TITLE
API-GATEWAY 구성도 및 자체 엔드포인트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ service 단위의 api을 관리합니다.
 nest new api-gateway
 ```
 
+## issue
+
+### build 후 `dist/main` 경로에 파일 없음
+
+version을 기록하기 위해 `tsconfig.json` 에 `"resolveJsonModule": true` 활성화 하여 `package.json` 의 `version` 속성을 import 하여 사용하게 되면서 build 시 `src` 디렉터리 외부의 파일을 끌어와야 하게 되었습니다.
+
+때문에 `dist` 가 아래와 같이 생성되면서 `"start:prod": "node dist/main"` 의 경로를 수정하게 되었습니다.
+
+```
+./dist
+ ├─src
+ ├─package.json
+ └─tsconfig.build.tsbuildinfo
+```
+
 ## pipeline
 
 ### origin인 `front-server` 와 다른점

--- a/package-lock.json
+++ b/package-lock.json
@@ -4260,6 +4260,11 @@
         "is-docker": "^2.0.0"
       }
     },
+    "is_js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
+      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -5339,6 +5344,14 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "nestjs-real-ip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nestjs-real-ip/-/nestjs-real-ip-1.0.2.tgz",
+      "integrity": "sha512-yEqjH+7wpM0jooavaUrjFitbE2p1uCjYEt1v0a5USHrUyhCYySEj8QrEF1+rKlqOJoP4690o4d3MYScV4Sp1FQ==",
+      "requires": {
+        "request-ip": "^2.1.3"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -6033,6 +6046,14 @@
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
+      }
+    },
+    "request-ip": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.1.3.tgz",
+      "integrity": "sha512-J3qdE/IhVM3BXkwMIVO4yFrvhJlU3H7JH16+6yHucadT4fePnR8dyh+vEs6FIx0S2x5TCt2ptiPfHcn0sqhbYQ==",
+      "requires": {
+        "is_js": "^0.9.0"
       }
     },
     "request-promise-core": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,13 +1,27 @@
-import { Controller, Get } from "@nestjs/common";
-import { AppService, HelloRes } from "./app.service";
+import { Controller, Get, Req, Res } from "@nestjs/common";
+import { AppService } from "./app.service";
+import { Request, Response } from "express";
+import { CCommonManager } from "./common/common.manager";
+import { CServerManager } from "./common/common.server-manager";
+import { User } from "./common/common.decorator";
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): HelloRes {
-    return this.appService.getHello();
+  root(@User() user): string {
+    return user;
+  }
+
+  @Get("ping")
+  sendStatusOK(@Req() req: Request, @Res() res: Response): any {
+    return res.sendStatus(200);
+  }
+
+  @Get("status")
+  async getStatus(): Promise<CCommonManager> {
+    return CServerManager.getInstance();
   }
 
   @Get(`/env`)

--- a/src/common/common.decorator.ts
+++ b/src/common/common.decorator.ts
@@ -1,0 +1,14 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { CUser } from "src/user/user";
+import { CCommonManager } from "./common.manager";
+
+export const User = createParamDecorator((data: string, ctx: ExecutionContext) => {
+  const request: Request = ctx.switchToHttp().getRequest();
+  let jwtToken = request.headers[""];
+  let user: CUser = null;
+  jwtToken = "12";
+  if (jwtToken) {
+    user = CCommonManager.getUserByJWT(jwtToken);
+  }
+  return data ? user?.[data] : user;
+});

--- a/src/common/common.interface.ts
+++ b/src/common/common.interface.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface ServerInfo {
+  status: number;
+  version: string;
+  name: string;
+}

--- a/src/common/common.manager.ts
+++ b/src/common/common.manager.ts
@@ -1,0 +1,22 @@
+import { CUser } from "src/user/user";
+
+/**
+ * @class CCommonManager
+ * @author Seungup
+ * @abstract 공통메니저 클래스
+ * @argument void
+ */
+export class CCommonManager {
+  private static instance: CCommonManager;
+
+  static getInstance() {
+    if (!CCommonManager.instance) {
+      CCommonManager.instance = new CCommonManager();
+    }
+    return CCommonManager.instance;
+  }
+
+  static getUserByJWT(jwtToken: string): CUser | undefined {
+    return new CUser(jwtToken); // for debuging todo : renew this line
+  }
+}

--- a/src/common/common.server-manager.ts
+++ b/src/common/common.server-manager.ts
@@ -1,0 +1,48 @@
+import { version } from "../../package.json";
+import { HttpStatus } from "@nestjs/common";
+
+/**
+ * @class CServerManager
+ * @author Seungup
+ * @abstract 공통 서버 메니저 클래스
+ * @argument void
+ */
+export class CServerManager {
+  private static instance: CServerManager;
+  servers: ServerInfo[] = [];
+
+  constructor() {
+    const defaultVersion = "unknown";
+
+    const defaultPing = HttpStatus.FORBIDDEN;
+
+    this.servers.push({
+      name: "mock-server",
+      status: defaultPing,
+      version: defaultVersion,
+    });
+
+    this.servers.push({
+      name: "product-server",
+      status: defaultPing,
+      version: defaultVersion,
+    });
+
+    this.servers.push({
+      name: "api-gateway",
+      status: HttpStatus.OK,
+      version: version,
+    });
+  }
+
+  static getInstance() {
+    if (!CServerManager.instance) {
+      CServerManager.instance = new CServerManager();
+    }
+    return CServerManager.instance;
+  }
+
+  update() {
+    CServerManager.instance = new CServerManager();
+  }
+}

--- a/src/filters/http-exception.filter.ts
+++ b/src/filters/http-exception.filter.ts
@@ -1,0 +1,18 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException } from "@nestjs/common";
+import { Request, Response } from "express";
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const status = exception.getStatus();
+
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
+import { HttpExceptionFilter } from "./filters/http-exception.filter";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalFilters(new HttpExceptionFilter());
   await app.listen(3000);
 }
 bootstrap();

--- a/src/middleware/logger.middleware.ts
+++ b/src/middleware/logger.middleware.ts
@@ -1,0 +1,9 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  async use(request: Request, response: Response, next: () => void): Promise<any> {
+    console.log(`${new Date().toISOString()} - ${request.method} - ${request.url}`);
+    next();
+  }
+}

--- a/src/middleware/login.middleware.ts
+++ b/src/middleware/login.middleware.ts
@@ -1,0 +1,17 @@
+import { HttpException, HttpService, HttpStatus, Injectable, NestMiddleware } from "@nestjs/common";
+
+@Injectable()
+export class LoginRequire implements NestMiddleware {
+  async use(request: Request, response: Response, next: () => void): Promise<any> {
+    const authorization = request.headers["Authorization"];
+    if (authorization && process.env.STAGES) {
+      const http = new HttpService();
+      // TODO 로그인 유효성 검사 로직이 추가되어야함.
+      const res = await http.get(`http://www.google.com/`).toPromise();
+      console.log(res.data);
+      next();
+    } else {
+      throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
+    }
+  }
+}

--- a/src/user/user.ts
+++ b/src/user/user.ts
@@ -1,0 +1,11 @@
+export class CUser {
+  id: string;
+  nickname: string;
+  constructor(jwtToken?: string) {
+    if (jwtToken) {
+      console.log(jwtToken);
+    }
+    this.id = "anonymous";
+    this.nickname = "anonymous";
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "incremental": true
+    "incremental": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
# #7 API-GATEWAY 구조 설정

## 설명
기본적으로 nestjs 에서 핸들링해야하는 에러 핸들링 및 자체적으로 가져야하는 엔드포인트 2개를 추가했습니다

## 시나리오
1. "/" 으로 접근하여 user의 값이 정상적으로 출력되는지 확인 - 현재는 하드코딩되어있음.
2. "/ping" 으로 접근하여 OK 또는 200 을 받았는지 확인
3. "/status" 으로 접근하여 mock, api-gateway, prod 서버에 대한 정보가 출력되는지 확인 - 현재는 하드코딩되어있음.
 