### PR TITLE
up: work_todo 생성 시 activeDate 입력 위한 API 폼 추가

### DIFF
--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -58,7 +58,8 @@ Content-Type: application/json
     "courseId": 1,
     "recurringCycleDate": 1,
     "title": "나만의 할 일1",
-    "explanation": "나만의 할 일 설명1"
+    "explanation": "나만의 할 일 설명1",
+    "activeDate": "2021-11-05T08:50:00.12"
 }
 
 ### work_todo 전체 리스트 가져오기


### PR DESCRIPTION
# 변경 내역

1. work_todo 생성 시 activeDate 값의 에시를 REST API json 항목에 추가