### PR TITLE
up: work todo 생성 시 반복 요일 정보 입력 가능하게 기능 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api-gateway",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1396,9 +1396,9 @@
       }
     },
     "@types/node": {
-      "version": "14.17.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.26.tgz",
-      "integrity": "sha512-eSTNkK/nfmnC7IKpOJZixDgG0W2/eHz1qyFN7o/rwwwIHsVRp+G9nbh4BrQ77kbQ2zPu286AQRxkuRLPcR3gXw==",
+      "version": "14.17.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
+      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-gateway",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "author": "",
   "private": true,
@@ -40,7 +40,7 @@
     "@types/express": "^4.17.11",
     "@types/jest": "^26.0.22",
     "@types/multer": "^1.4.7",
-    "@types/node": "^14.17.26",
+    "@types/node": "^14.17.32",
     "@types/supertest": "^2.0.10",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/src/common/type/work-todo-post.interface.ts
+++ b/src/common/type/work-todo-post.interface.ts
@@ -1,6 +1,5 @@
-import { RepeatedDaysOfTheWeekType } from "./repeated-days-of-the-week.type";
 import { WorkTodoType } from "./work-todo.type";
 
 export interface WorkTodoPostInterface extends WorkTodoType {
-  repeatedDaysOfTheWeek?: RepeatedDaysOfTheWeekType[];
+  repeatedDaysOfTheWeek: number[];
 }

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -47,7 +47,8 @@ Content-Type: application/json
 
 {
     "courseId": 1,
-    "title": "나만의 할 일1"
+    "title": "나만의 할 일1",
+    "repeatedDaysOfTheWeek": []
 }
 
 ### work_todo 추가(선택)
@@ -56,10 +57,11 @@ Content-Type: application/json
 
 {
     "courseId": 1,
-    "recurringCycleDate": 1,
     "title": "나만의 할 일1",
-    "explanation": "나만의 할 일 설명1",
-    "activeDate": "2021-11-05T08:50:00.12"
+    "repeatedDaysOfTheWeek": [1, 2, 3],
+    "activeDate": "2021-11-05T08:50:00.12",
+    "recurringCycleDate": 1,
+    "explanation": "나만의 할 일 설명1"
 }
 
 ### work_todo 전체 리스트 가져오기


### PR DESCRIPTION
# 변경 내역

1. type 코드를 수정해 work todo 생성 시 todo service에서 반복 요일 정보를 전달 받을 수 있도록 수정
2. 버전 정보 업데이트
3. 패키지 업데이트