### PR TITLE
한일을 POST 요청할 시 JWT 토큰에서 유저 ID 값을 가져오도록 수정

### DIFF
--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -19,6 +19,6 @@ import { K8sServiceDNS } from "../common/lib/service";
 })
 export class MiddlewareModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(OauthMiddleware).forRoutes({ path: "/todo/courses", method: RequestMethod.POST });
+    consumer.apply(OauthMiddleware).forRoutes({ path: "/todo/courses", method: RequestMethod.POST }, { path: "/todo/work-dones", method: RequestMethod.POST });
   }
 }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -221,7 +221,6 @@ export class TodoController {
 
       throw new HttpException(message, httpStatusCode);
     }
-
     return serviceResult;
   }
 

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -209,11 +209,11 @@ export class TodoController {
 
   // WorkDone
   @Post("work-dones")
-  async createWorkDone(@Body() workDoneInput: WorkDoneType) {
+  async createWorkDone(@Headers() headers: Record<string, string>, @Body() workDoneInput: WorkDoneType) {
     let serviceResult: any;
 
     try {
-      const result: AxiosResponse<any> = await this.appService.createWorkDone(workDoneInput);
+      const result: AxiosResponse<any> = await this.appService.createWorkDone(workDoneInput, headers);
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -76,13 +76,13 @@ DELETE {{Host}}/{{Router}}/work-todos/1
 
 ### work_done 추가
 POST {{Host}}/{{Router}}/work-dones
+authorization: 
 Content-Type: application/json
 
 {
     "workTodoId": 1,
     "title": "한 일의 제목1",
-    "content": "json 컨텐츠 1",
-    "userId": 1
+    "content": "json 컨텐츠 1"
 }
 
 ### work_done 전체 리스트 가져오기

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -181,10 +181,11 @@ export class TodoService {
   }
 
   // WorkDone
-  async createWorkDone(workDoneInput: WorkDoneType) {
+  async createWorkDone(workDoneInput: WorkDoneType, headers: Record<string, string>) {
     let apiClientResult: any;
 
     try {
+      workDoneInput.userId = this.belfJwtService.getUserId(headers["authorization"]);
       apiClientResult = await this.todoApiClient.createWorkDone(workDoneInput);
     } catch (error) {
       throw error;


### PR DESCRIPTION
# 변경 내역

1.  JWT 토큰에서 userId를 가져와 work_done 테이블을 Create하도록 수정했습니다.

# 변경 사유

1. 기존에는 POST 요청시 Body 에 userId 키가 존재하여야 Create가 가능하였으나, 이를 JWT 토큰으로 변경하여 보안을 높였습니다.

# 테스트 방법

1. QA 배포 후 헤더에 가용가능한 JWT 토큰을 `authorization`에  포함하여 `/work-dones`에 `POST` 요청을 보내봅니다.