### PR TITLE
work_todo 입력 시 courseId 값을 JWT에서 입력기능 추가

### DIFF
--- a/src/common/type/work-todo.type.ts
+++ b/src/common/type/work-todo.type.ts
@@ -5,4 +5,5 @@ export type WorkTodoType = {
   explanation?: string;
   activeDate: Date;
   courseId: number;
+  userId: number;
 };

--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -19,6 +19,12 @@ import { K8sServiceDNS } from "../common/lib/service";
 })
 export class MiddlewareModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(OauthMiddleware).forRoutes({ path: "/todo/courses", method: RequestMethod.POST }, { path: "/todo/work-dones", method: RequestMethod.POST });
+    consumer
+      .apply(OauthMiddleware)
+      .forRoutes(
+        { path: "/todo/courses", method: RequestMethod.POST },
+        { path: "/todo/work-todos", method: RequestMethod.POST },
+        { path: "/todo/work-dones", method: RequestMethod.POST }
+      );
   }
 }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -157,11 +157,12 @@ export class TodoController {
 
   // WorkTodo
   @Post("work-todos")
-  async createWorkTodo(@Body() workTodoPostInput: WorkTodoPostInterface) {
+  async createWorkTodo(@Headers() headers: Record<string, string>, @Body() workTodoPostInput: WorkTodoPostInterface) {
     let serviceResult: any;
 
     try {
-      const result: AxiosResponse<any> = await this.appService.createWorkTodo(workTodoPostInput);
+      const result: AxiosResponse<any> = await this.appService.createWorkTodo(workTodoPostInput, headers);
+
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -44,6 +44,7 @@ DELETE {{Host}}/{{Router}}/courses/1
 
 ### work_todo 추가(필수)
 POST {{Host}}/{{Router}}/work-todos
+authorization: 
 Content-Type: application/json
 
 {
@@ -54,6 +55,7 @@ Content-Type: application/json
 
 ### work_todo 추가(선택)
 POST {{Host}}/{{Router}}/work-todos
+authorization: 
 Content-Type: application/json
 
 {

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -144,8 +144,9 @@ export class TodoService {
   }
 
   // WorkTodo
-  async createWorkTodo(workTodoInput: WorkTodoType) {
+  async createWorkTodo(workTodoInput: WorkTodoType, headers: Record<string, string>) {
     let apiClientResult: any;
+    workTodoInput.userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
       apiClientResult = await this.todoApiClient.createWorkTodo(workTodoInput);


### PR DESCRIPTION
# 변경 내역

1. work_todo를 입력할 때 userId 값을 JWT 디코딩 된 값에서 가져와 todo service를 호출하는 기능을 추가했습니다.

# 개선점

1. work_todo를 입력한 사람이 누구인지 확인하는 로직을 API gateway에서 모두 제어할 수 있게 되었습니다.

# 테스트 방법

1. work_todo를 입력하는 API gateway의 http endpoint를 호출한 다음, 201 created HTTP 응답 코드가 나오는지 확인합니다.
2. 1번에서 실제 생성한 work_todo 값이 생성 되었는지 work_todo 전체를 조회하는 API endpoint를 호출해 확인합니다.