### PR TITLE
Get, Delete 요청시 userId를 JWT에서 가져와 요청하는 기능 추가

### DIFF
--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -22,12 +22,9 @@ export class MiddlewareModule implements NestModule {
     consumer
       .apply(OauthMiddleware)
       .forRoutes(
-        { path: "/todo/courses", method: RequestMethod.GET },
-        { path: "/todo/courses", method: RequestMethod.POST },
-        { path: "/todo/work-todos", method: RequestMethod.GET },
-        { path: "/todo/work-todos", method: RequestMethod.POST },
-        { path: "/todo/work-dones", method: RequestMethod.GET },
-        { path: "/todo/work-dones", method: RequestMethod.POST }
+        { path: "/todo/courses", method: RequestMethod.ALL },
+        { path: "/todo/work-todos", method: RequestMethod.ALL },
+        { path: "/todo/work-dones", method: RequestMethod.ALL }
       );
   }
 }

--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -22,8 +22,11 @@ export class MiddlewareModule implements NestModule {
     consumer
       .apply(OauthMiddleware)
       .forRoutes(
+        { path: "/todo/courses", method: RequestMethod.GET },
         { path: "/todo/courses", method: RequestMethod.POST },
+        { path: "/todo/work-todos", method: RequestMethod.GET },
         { path: "/todo/work-todos", method: RequestMethod.POST },
+        { path: "/todo/work-dones", method: RequestMethod.GET },
         { path: "/todo/work-dones", method: RequestMethod.POST }
       );
   }

--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -189,11 +189,12 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async getWorkDone(id: number): Promise<AxiosResponse<any>> {
+  async getWorkDone(userId: number, id: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
+    const querystring = userId ? `?userId=${userId}` : "";
 
     try {
-      serviceResult = await this.httpService.get("/work-dones/" + id).toPromise();
+      serviceResult = await this.httpService.get("/work-dones/" + id + querystring).toPromise();
     } catch (error) {
       throw error;
     }

--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -107,11 +107,12 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async deleteCourse(id: number): Promise<AxiosResponse<any>> {
+  async deleteCourse(userId: number, id: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
+    const querystring = userId ? `?userId=${userId}` : "";
 
     try {
-      serviceResult = await this.httpService.delete("/courses/" + id).toPromise();
+      serviceResult = await this.httpService.delete("/courses/" + id + querystring).toPromise();
     } catch (error) {
       throw error;
     }
@@ -147,11 +148,12 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async deleteWorkTodo(id: number): Promise<AxiosResponse<any>> {
+  async deleteWorkTodo(userId: number, id: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
+    const querystring = userId ? `?userId=${userId}` : "";
 
     try {
-      serviceResult = await this.httpService.delete("/work-todos/" + id).toPromise();
+      serviceResult = await this.httpService.delete("/work-todos/" + id + querystring).toPromise();
     } catch (error) {
       throw error;
     }
@@ -192,6 +194,19 @@ export class TodoApiClient {
 
     try {
       serviceResult = await this.httpService.get("/work-dones/" + id).toPromise();
+    } catch (error) {
+      throw error;
+    }
+
+    return serviceResult;
+  }
+
+  async deleteWorkDone(userId: number, id: number): Promise<AxiosResponse<any>> {
+    let serviceResult: any;
+    const querystring = userId ? `?userId=${userId}` : "";
+
+    try {
+      serviceResult = await this.httpService.delete("/work-dones/" + id + querystring).toPromise();
     } catch (error) {
       throw error;
     }

--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -93,11 +93,13 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async getAllCourses(): Promise<AxiosResponse<any>> {
+  async getAllCourses(userId: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
 
     try {
-      serviceResult = await this.httpService.get("/courses").toPromise();
+      const querystring = userId ? `?userId=${userId}` : "";
+
+      serviceResult = await this.httpService.get("/courses" + querystring).toPromise();
     } catch (error) {
       throw error;
     }
@@ -130,12 +132,14 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async getWorkTodosByConditions(courseId?: number): Promise<AxiosResponse<any>> {
+  async getWorkTodosByConditions(userId: number, courseId?: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
 
     try {
-      const queryString = courseId ? `?courseId=${courseId}` : "";
-      serviceResult = await this.httpService.get("/work-todos" + queryString).toPromise();
+      let querystring = userId ? `?userId=${userId}` : "";
+      querystring = courseId ? querystring + `&courseId=${courseId}` : querystring;
+
+      serviceResult = await this.httpService.get("/work-todos" + querystring).toPromise();
     } catch (error) {
       throw error;
     }
@@ -168,12 +172,14 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async getWorkDoneByConditions(courseId?: number): Promise<AxiosResponse<any>> {
+  async getWorkDoneByConditions(userId: number, courseId?: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
 
     try {
-      const queryString = courseId ? `?courseId=${courseId}` : "";
-      serviceResult = await this.httpService.get("/work-dones" + queryString).toPromise();
+      let querystring = userId ? `?userId=${userId}` : "";
+      querystring = courseId ? querystring + `&courseId=${courseId}` : querystring;
+
+      serviceResult = await this.httpService.get("/work-dones" + querystring).toPromise();
     } catch (error) {
       throw error;
     }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -122,11 +122,12 @@ export class TodoController {
   }
 
   @Get("courses")
-  async getAllCourses() {
+  async getAllCourses(@Headers() headers: Record<string, string>) {
     let serviceResult: CourseGetInterface[];
 
     try {
-      const result: AxiosResponse<any> = await this.appService.getAllCourses();
+      const result: AxiosResponse<any> = await this.appService.getAllCourses(headers);
+
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
@@ -175,11 +176,12 @@ export class TodoController {
   }
 
   @Get("work-todos")
-  async getWorkTodosByConditions(@Query("courseId") courseId?: number) {
+  async getWorkTodosByConditions(@Headers() headers: Record<string, string>, @Query("courseId") courseId?: number) {
     let serviceResult: WorkTodoGetInterface[];
 
     try {
-      const result: AxiosResponse<any> = await this.appService.getWorkTodosByConditions(courseId);
+      const result: AxiosResponse<any> = await this.appService.getWorkTodosByConditions(headers, courseId);
+
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
@@ -226,11 +228,12 @@ export class TodoController {
   }
 
   @Get("work-dones")
-  async getWorkDonesByConditions(@Query("courseId") courseId?: number) {
+  async getWorkDonesByConditions(@Headers() headers: Record<string, string>, @Query("courseId") courseId?: number) {
     let serviceResult: any;
 
     try {
-      const result: AxiosResponse<any> = await this.appService.getWorkDonesByConditions(courseId);
+      const result: AxiosResponse<any> = await this.appService.getWorkDonesByConditions(headers, courseId);
+
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -140,11 +140,11 @@ export class TodoController {
   }
 
   @Delete("courses/:id")
-  async deleteCourse(@Param("id") id: number) {
+  async deleteCourse(@Headers() headers: Record<string, string>, @Param("id") id: number) {
     let serviceResult: any;
 
     try {
-      const result: AxiosResponse<any> = await this.appService.deleteCourse(id);
+      const result: AxiosResponse<any> = await this.appService.deleteCourse(headers, id);
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
@@ -194,11 +194,11 @@ export class TodoController {
   }
 
   @Delete("work-todos/:id")
-  async deleteWorkTodo(@Param() params: any) {
+  async deleteWorkTodo(@Headers() headers: Record<string, string>, @Param("id") id: number) {
     let serviceResult: any;
 
     try {
-      const result: AxiosResponse<any> = await this.appService.deleteWorkTodo(params.id);
+      const result: AxiosResponse<any> = await this.appService.deleteWorkTodo(headers, id);
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
@@ -251,6 +251,23 @@ export class TodoController {
 
     try {
       const result: AxiosResponse<any> = await this.appService.getWorkDone(params.id);
+      serviceResult = result.data;
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      throw new HttpException(message, httpStatusCode);
+    }
+
+    return serviceResult;
+  }
+
+  @Delete("work-dones/:id")
+  async deleteWorkDone(@Headers() headers: Record<string, string>, @Param("id") id: number) {
+    let serviceResult: any;
+
+    try {
+      const result: AxiosResponse<any> = await this.appService.deleteWorkDone(headers, id);
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -246,11 +246,11 @@ export class TodoController {
   }
 
   @Get("work-dones/:id")
-  async getWorkDone(@Param() params: any) {
+  async getWorkDone(@Headers() headers: Record<string, string>, @Param("id") id: number) {
     let serviceResult: any;
 
     try {
-      const result: AxiosResponse<any> = await this.appService.getWorkDone(params.id);
+      const result: AxiosResponse<any> = await this.appService.getWorkDone(headers, id);
       serviceResult = result.data;
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -19,6 +19,7 @@ GET {{Host}}/{{Router}}/colors
 
 ### course 정보 전체 조회
 GET {{Host}}/{{Router}}/courses
+authorization: 
 
 ### course 생성
 POST {{Host}}/{{Router}}/courses
@@ -69,9 +70,11 @@ Content-Type: application/json
 
 ### work_todo 전체 리스트 가져오기
 GET {{Host}}/{{Router}}/work-todos
+authorization: 
 
 ### work_todo 리스트 가져오기
 GET {{Host}}/{{Router}}/work-todos?courseId=1
+authorization: 
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/work-todos/1
@@ -89,9 +92,11 @@ Content-Type: application/json
 
 ### work_done 전체 리스트 가져오기
 GET {{Host}}/{{Router}}/work-dones
+authorization: 
 
 ### work_done 리스트 가져오기
 GET {{Host}}/{{Router}}/work-dones?courseId=1
+authorization: 
 
 ### work_done 디테일
 GET {{Host}}/{{Router}}/work-dones/1

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -42,6 +42,7 @@ Content-Type: application/json
 
 ### course 삭제
 DELETE {{Host}}/{{Router}}/courses/1
+authorization: 
 
 ### work_todo 추가(필수)
 POST {{Host}}/{{Router}}/work-todos
@@ -78,6 +79,7 @@ authorization:
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/work-todos/1
+authorization: 
 
 ### work_done 추가
 POST {{Host}}/{{Router}}/work-dones
@@ -100,3 +102,8 @@ authorization:
 
 ### work_done 디테일
 GET {{Host}}/{{Router}}/work-dones/1
+authorization: 
+
+### work_done 삭제
+DELETE {{Host}}/{{Router}}/work-dones/1
+authorization: 

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -212,11 +212,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async getWorkDone(id: number) {
+  async getWorkDone(headers: Record<string, string>, id: number) {
     let apiClientResult: any;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.getWorkDone(id);
+      apiClientResult = await this.todoApiClient.getWorkDone(userId, id);
     } catch (error) {
       throw error;
     }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -119,11 +119,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async getAllCourses() {
+  async getAllCourses(headers: Record<string, string>) {
     let apiClientResult: any;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.getAllCourses();
+      apiClientResult = await this.todoApiClient.getAllCourses(userId);
     } catch (error) {
       throw error;
     }
@@ -157,11 +158,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async getWorkTodosByConditions(courseId?: number) {
+  async getWorkTodosByConditions(headers: Record<string, string>, courseId?: number) {
     let apiClientResult: any;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.getWorkTodosByConditions(courseId);
+      apiClientResult = await this.todoApiClient.getWorkTodosByConditions(userId, courseId);
     } catch (error) {
       throw error;
     }
@@ -195,11 +197,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async getWorkDonesByConditions(courseId?: number) {
+  async getWorkDonesByConditions(headers: Record<string, string>, courseId?: number) {
     let apiClientResult: any;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.getWorkDoneByConditions(courseId);
+      apiClientResult = await this.todoApiClient.getWorkDoneByConditions(userId, courseId);
     } catch (error) {
       throw error;
     }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -132,11 +132,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async deleteCourse(id: number) {
+  async deleteCourse(headers: Record<string, string>, id: number) {
     let apiClientResult: any;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.deleteCourse(id);
+      apiClientResult = await this.todoApiClient.deleteCourse(userId, id);
     } catch (error) {
       throw error;
     }
@@ -171,11 +172,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async deleteWorkTodo(id: number) {
+  async deleteWorkTodo(headers: Record<string, string>, id: number) {
     let apiClientResult: any;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.deleteWorkTodo(id);
+      apiClientResult = await this.todoApiClient.deleteWorkTodo(userId, id);
     } catch (error) {
       throw error;
     }
@@ -215,6 +217,19 @@ export class TodoService {
 
     try {
       apiClientResult = await this.todoApiClient.getWorkDone(id);
+    } catch (error) {
+      throw error;
+    }
+
+    return apiClientResult;
+  }
+
+  async deleteWorkDone(headers: Record<string, string>, id: number) {
+    let apiClientResult: any;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
+
+    try {
+      apiClientResult = await this.todoApiClient.deleteWorkDone(userId, id);
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
# 변경 내역

1. Todo service 내부의 Table 들에 대한 HTTP Get 요청시 JWT를 디코딩해 userId 값을 넣어 HTTP Get 요청을 보내는 기능 추가
2. Todo service 내부의 Table들에 대한 HTTP Delete 요청시 query string에서 userId 값을 가져와 필터링 하는 기능 추가

# 변경 사유

1. 다른 유저의 데이터를 볼 수 없게 하기 위해서
2. 추후 데이터 가공 기능 추가시 뼈대가 되는 데이터를 최소화 하여 DB, Server 단에서의 컴퓨팅 자원을 절약하기 위해

# 테스트 방법

1. HTTP Get 요청시 JWT 토큰 값을 header에 넣어 해당 유저의 데이터만 반환되는지 확인합니다.
2. HTTP Delete 요청시 JWT 토큰 값을 header에 넣어 해당 유저의 데이터만 삭제되는지 확인합니다.