### PR TITLE
반복 일수에 따라 반복되는 work-todo 리스트 가져오는 API endpoint 추가

### DIFF
--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -174,12 +174,14 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async getWorkDoneByConditions(userId: number, courseId?: number): Promise<AxiosResponse<any>> {
+  async getWorkDoneByConditions(userId: number, courseId?: number, activeDate?: Date, maximumActiveDate?: Date): Promise<AxiosResponse<any>> {
     let serviceResult: any;
 
     try {
       let querystring = userId ? `?userId=${userId}` : "";
       querystring = courseId ? querystring + `&courseId=${courseId}` : querystring;
+      querystring = courseId ? querystring + `&activeDate=${activeDate}` : querystring;
+      querystring = courseId ? querystring + `&maximumActiveDate=${maximumActiveDate}` : querystring;
 
       serviceResult = await this.httpService.get("/work-dones" + querystring).toPromise();
     } catch (error) {

--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -133,12 +133,14 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async getWorkTodosByConditions(userId: number, courseId?: number): Promise<AxiosResponse<any>> {
+  async getWorkTodosByConditions(userId: number, courseId?: number, activeDate?: Date, maximumActiveDate?: Date): Promise<AxiosResponse<any>> {
     let serviceResult: any;
 
     try {
       let querystring = userId ? `?userId=${userId}` : "";
       querystring = courseId ? querystring + `&courseId=${courseId}` : querystring;
+      querystring = courseId ? querystring + `&activeDate=${activeDate}` : querystring;
+      querystring = courseId ? querystring + `&maximumActiveDate=${maximumActiveDate}` : querystring;
 
       serviceResult = await this.httpService.get("/work-todos" + querystring).toPromise();
     } catch (error) {

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -228,11 +228,16 @@ export class TodoController {
   }
 
   @Get("work-dones")
-  async getWorkDonesByConditions(@Headers() headers: Record<string, string>, @Query("courseId") courseId?: number) {
+  async getWorkDonesByConditions(
+    @Headers() headers: Record<string, string>,
+    @Query("courseId") courseId?: number,
+    @Query("activeDate") activeDate?: Date,
+    @Query("maximumActiveDate") maximumActiveDate?: Date
+  ) {
     let serviceResult: any;
 
     try {
-      const result: AxiosResponse<any> = await this.appService.getWorkDonesByConditions(headers, courseId);
+      const result: AxiosResponse<any> = await this.appService.getWorkDonesByConditions(headers, courseId, activeDate, maximumActiveDate);
 
       serviceResult = result.data;
     } catch (error) {

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -228,16 +228,11 @@ export class TodoController {
   }
 
   @Get("work-dones")
-  async getWorkDonesByConditions(
-    @Headers() headers: Record<string, string>,
-    @Query("courseId") courseId?: number,
-    @Query("activeDate") activeDate?: Date,
-    @Query("maximumActiveDate") maximumActiveDate?: Date
-  ) {
+  async getWorkDonesByConditions(@Headers() headers: Record<string, string>, @Query("courseId") courseId?: number) {
     let serviceResult: any;
 
     try {
-      const result: AxiosResponse<any> = await this.appService.getWorkDonesByConditions(headers, courseId, activeDate, maximumActiveDate);
+      const result: AxiosResponse<any> = await this.appService.getWorkDonesByConditions(headers, courseId);
 
       serviceResult = result.data;
     } catch (error) {

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -176,11 +176,16 @@ export class TodoController {
   }
 
   @Get("work-todos")
-  async getWorkTodosByConditions(@Headers() headers: Record<string, string>, @Query("courseId") courseId?: number) {
+  async getWorkTodosByConditions(
+    @Headers() headers: Record<string, string>,
+    @Query("courseId") courseId?: number,
+    @Query("activeDate") activeDate?: Date,
+    @Query("maximumActiveDate") maximumActiveDate?: Date
+  ) {
     let serviceResult: WorkTodoGetInterface[];
 
     try {
-      const result: AxiosResponse<any> = await this.appService.getWorkTodosByConditions(headers, courseId);
+      const result: AxiosResponse<any> = await this.appService.getWorkTodosByConditions(headers, courseId, activeDate, maximumActiveDate);
 
       serviceResult = result.data;
     } catch (error) {

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -73,9 +73,8 @@ Content-Type: application/json
 GET {{Host}}/{{Router}}/work-todos
 authorization: 
 
-### work_todo 리스트 가져오기
-GET {{Host}}/{{Router}}/work-todos?courseId=1
-authorization: 
+### work_todo 조건에 알맞은 리스트 가져오기
+GET {{Host}}/{{Router}}?courseId=&activeDate=&maximumActiveDate=
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/work-todos/1

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -75,6 +75,7 @@ authorization:
 
 ### work_todo 조건에 알맞은 리스트 가져오기
 GET {{Host}}/{{Router}}?courseId=&activeDate=&maximumActiveDate=
+authorization: 
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/work-todos/1

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -159,12 +159,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async getWorkTodosByConditions(headers: Record<string, string>, courseId?: number) {
+  async getWorkTodosByConditions(headers: Record<string, string>, courseId?: number, activeDate?: Date, maximumActiveDate?: Date) {
     let apiClientResult: any;
     const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.getWorkTodosByConditions(userId, courseId);
+      apiClientResult = await this.todoApiClient.getWorkTodosByConditions(userId, courseId, activeDate, maximumActiveDate);
     } catch (error) {
       throw error;
     }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -199,12 +199,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async getWorkDonesByConditions(headers: Record<string, string>, courseId?: number, activeDate?: Date, maximumActiveDate?: Date) {
+  async getWorkDonesByConditions(headers: Record<string, string>, courseId?: number) {
     let apiClientResult: any;
     const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.getWorkDoneByConditions(userId, courseId, activeDate, maximumActiveDate);
+      apiClientResult = await this.todoApiClient.getWorkDoneByConditions(userId, courseId);
     } catch (error) {
       throw error;
     }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -199,12 +199,12 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async getWorkDonesByConditions(headers: Record<string, string>, courseId?: number) {
+  async getWorkDonesByConditions(headers: Record<string, string>, courseId?: number, activeDate?: Date, maximumActiveDate?: Date) {
     let apiClientResult: any;
     const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.todoApiClient.getWorkDoneByConditions(userId, courseId);
+      apiClientResult = await this.todoApiClient.getWorkDoneByConditions(userId, courseId, activeDate, maximumActiveDate);
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
# 변경 내역

1. activeDate, maximumActiveDate 정보를 querystring으로 입력시 해당 기간동안 반복되는 work-todo 리스트 반환 API endpoint 추가

# 변경 이유

1. NextJS 에서 해당 기능 개발 요구

# 테스트 방법

1. HTTP Get 요청시 activeDate, maximumActiveDate 정보를 입력해서 recurringCycleDate work-todo가 반복되어 리스트 형태로 전달되는지 확인한다.