### PR TITLE
course Id 사용해 단일 course 가져오는 API Endpoint 추가

### DIFF
--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -106,6 +106,18 @@ export class TodoApiClient {
     return serviceResult;
   }
 
+  async getCourse(id: number): Promise<AxiosResponse<any>> {
+    let serviceResult: any;
+
+    try {
+      serviceResult = await this.httpService.delete("/courses/" + id).toPromise();
+    } catch (error) {
+      throw error;
+    }
+
+    return serviceResult;
+  }
+
   async deleteCourse(userId: number, id: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
     const querystring = userId ? `?userId=${userId}` : "";

--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -110,7 +110,7 @@ export class TodoApiClient {
     let serviceResult: any;
 
     try {
-      serviceResult = await this.httpService.delete("/courses/" + id).toPromise();
+      serviceResult = await this.httpService.get("/courses/" + id).toPromise();
     } catch (error) {
       throw error;
     }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -139,6 +139,23 @@ export class TodoController {
     return serviceResult;
   }
 
+  @Get("courses/:id")
+  async getCourse(@Param("id") id: number) {
+    let serviceResult: any;
+
+    try {
+      const result: AxiosResponse<any> = await this.appService.getCourse(id);
+      serviceResult = result.data;
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      throw new HttpException(message, httpStatusCode);
+    }
+
+    return serviceResult;
+  }
+
   @Delete("courses/:id")
   async deleteCourse(@Headers() headers: Record<string, string>, @Param("id") id: number) {
     let serviceResult: any;

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -20,6 +20,9 @@ GET {{Host}}/{{Router}}/colors
 ### course 정보 전체 조회
 GET {{Host}}/{{Router}}/courses
 
+### course 특정 조회
+GET {{Host}}/{{Router}}/courses/1
+
 ### course 조건으로 조회
 GET {{Host}}/{{Router}}/courses?userId=
 

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -131,6 +131,18 @@ export class TodoService {
     return apiClientResult;
   }
 
+  async getCourse(id: number) {
+    let apiClientResult: any;
+
+    try {
+      apiClientResult = await this.todoApiClient.getCourse(id);
+    } catch (error) {
+      throw error;
+    }
+
+    return apiClientResult;
+  }
+
   async deleteCourse(headers: Record<string, string>, id: number) {
     let apiClientResult: any;
     const userId = this.belfJwtService.getUserId(headers["authorization"]);


### PR DESCRIPTION
# 변경 내역

1. URL에 courseId 값을 입력해서 특정 코스를 가져올 수 있는 API endpoint 추가

# 변경 사유

1. @algo2000 개발자의 요청

# 테스트 방법

1. 새롭게 추가된 courses/? url에 특정 courseId 값을 입력해서 특정 코스 정보만 반환되는지 확인