### PR TITLE
Color 생성 기능 API endpoint 추가

### DIFF
--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -1,6 +1,7 @@
 import { HttpService, Injectable } from "@nestjs/common";
 import { AxiosResponse } from "axios";
 
+import { ColorType } from "src/common/type/color.type";
 import { CourseType } from "src/common/type/course.type";
 import { WorkTodoType } from "src/common/type/work-todo.type";
 import { WorkDoneType } from "src/common/type/work-done.type";
@@ -73,6 +74,18 @@ export class TodoApiClient {
 
     try {
       serviceResult = await this.httpService.get("/colors").toPromise();
+    } catch (error) {
+      throw error;
+    }
+
+    return serviceResult;
+  }
+
+  async createColor(colorInput: ColorType) {
+    let serviceResult: any;
+
+    try {
+      serviceResult = await this.httpService.post("/colors", colorInput).toPromise();
     } catch (error) {
       throw error;
     }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -104,6 +104,23 @@ export class TodoController {
     return serviceResult;
   }
 
+  @Post("colors")
+  async createColor(@Body() colorInput: ColorType) {
+    let serviceResult: any;
+
+    try {
+      const result: AxiosResponse<any> = await this.appService.createColor(colorInput);
+      serviceResult = result.data;
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      throw new HttpException(message, httpStatusCode);
+    }
+
+    return serviceResult;
+  }
+
   @Post("courses")
   async createCourse(@Headers() headers: Record<string, string>, @Body() coursePostInput: CoursePostInterface) {
     let serviceResult: any;

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -17,6 +17,14 @@ GET {{Host}}/{{Router}}/version
 ### color 정보 전체 조회
 GET {{Host}}/{{Router}}/colors
 
+### Color 생성
+POST {{Host}}/{{Router}}/colors
+Content-Type: application/json
+
+{
+    "id": "#FFFFFF"
+}
+
 ### course 정보 전체 조회
 GET {{Host}}/{{Router}}/courses
 

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -6,6 +6,7 @@ import { MockApiClient } from "../mock/lib/api";
 
 import { BelfJwtService } from "src/belf-jwt/belf-jwt.service";
 
+import { ColorType } from "src/common/type/color.type";
 import { CourseType } from "src/common/type/course.type";
 import { WorkTodoType } from "src/common/type/work-todo.type";
 import { WorkDoneType } from "src/common/type/work-done.type";
@@ -99,6 +100,18 @@ export class TodoService {
 
     try {
       apiClientResult = await this.todoApiClient.getAllColors();
+    } catch (error) {
+      throw error;
+    }
+
+    return apiClientResult;
+  }
+
+  async createColor(colorInput: ColorType) {
+    let apiClientResult: any;
+
+    try {
+      apiClientResult = await this.todoApiClient.createColor(colorInput);
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
# 변경 내역

1. HTTP Post 사용해 새로운 color를 insert할 수 있는 기능 추가

# 변경 사유

1. production 서비스 환경의 DB가 재설정 된 경우 기본 color 정보를 넣을 수 있는 방법이 SQL 직접 실행 제외하곤 전무했음

# 테스트 방법

1. API endpoint 양식에 맞추어 Post 요청을 보냈을때 color 정보가 새롭게 추가되는지 확인한다.