### PR TITLE
course creatorId 컬럼명 변경에 따른 API 코드 변경

### DIFF
--- a/src/common/type/course.type.ts
+++ b/src/common/type/course.type.ts
@@ -2,7 +2,7 @@ export type CourseType = {
   id: number;
   originalCourseId?: number;
   color?: string;
-  creatorId?: number;
+  userId?: number;
   startDate?: Date;
   endDate?: Date;
   explanation?: string;

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -121,7 +121,7 @@ export class TodoService {
 
   async createCourse(courseInput: CourseType, headers: Record<string, string>) {
     let apiClientResult: any;
-    courseInput.creatorId = this.belfJwtService.getUserId(headers["authorization"]);
+    courseInput.userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
       apiClientResult = await this.todoApiClient.createCourse(courseInput);


### PR DESCRIPTION
# 변경 내역

1. Course와 관련된 API 코드중 creatorId 변수명을 userId 변수명으로 변경

# 변경 사유

1. Todo 서비스 변경에 따른 코드명 리펙토링

# 테스트 방법

1. 코스와 관련해 기존에 생성해둔 Get, Post 기능을 사용해 코스가 정상적으로 조회, 생성 되는지 확인