### PR TITLE
파일 추가시 userId 입력기능 추가

### DIFF
--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -27,7 +27,8 @@ export class MiddlewareModule implements NestModule {
         { path: "/todo/work-todos", method: RequestMethod.POST },
         { path: "/todo/work-todos", method: RequestMethod.DELETE },
         { path: "/todo/work-dones", method: RequestMethod.POST },
-        { path: "/todo/work-dones", method: RequestMethod.DELETE }
+        { path: "/todo/work-dones", method: RequestMethod.DELETE },
+        { path: "/storage/upload", method: RequestMethod.POST }
       );
   }
 }

--- a/src/storage/lib/api.ts
+++ b/src/storage/lib/api.ts
@@ -63,12 +63,13 @@ export class StorageApiClient {
     return serviceResult;
   }
 
-  async uploadFile(file: any): Promise<any> {
+  async uploadFile(file: any, userId: number): Promise<any> {
     let serviceResult: any;
 
     try {
       const form = new FormData();
       form.append("file", file.buffer, { filename: file.originalname });
+      form.append("userId", userId);
       const res = await this.httpService
         .post("/api/v1/upload/", form, {
           headers: {

--- a/src/storage/storage.controller.ts
+++ b/src/storage/storage.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, UploadedFile, UseInterceptors, Param, HttpException } from "@nestjs/common";
+import { Controller, Get, Post, UploadedFile, UseInterceptors, Param, HttpException, Headers } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
 
 import { StorageService } from "./storage.service";
@@ -79,11 +79,11 @@ export class StorageController {
 
   @Post("upload")
   @UseInterceptors(FileInterceptor("file"))
-  async uploadFile(@UploadedFile() file): Promise<string> {
+  async uploadFile(@Headers() headers: Record<string, string>, @UploadedFile() file: any): Promise<string> {
     let serviceResult: string;
 
     try {
-      serviceResult = await this.appService.uploadFile(file);
+      serviceResult = await this.appService.uploadFile(headers, file);
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
       const message = getErrorMessage(error);

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -1,9 +1,12 @@
-import { K8sServiceDNS } from "src/common/lib/service";
-import { StorageController } from "./storage.controller";
-import { StorageService } from "./storage.service";
 import { HttpModule, Module } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
+
+import { StorageController } from "./storage.controller";
 import { StorageApiClient } from "./lib/api";
+import { StorageService } from "./storage.service";
+
+import { K8sServiceDNS } from "src/common/lib/service";
+import { BelfJwtModule } from "src/belf-jwt/belf-jwt.module";
 
 @Module({
   imports: [
@@ -15,6 +18,7 @@ import { StorageApiClient } from "./lib/api";
       inject: [ConfigService],
     }),
     StorageModule,
+    BelfJwtModule,
   ],
   controllers: [StorageController],
   providers: [StorageService, StorageApiClient],

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -3,12 +3,16 @@ import { AxiosResponse } from "axios";
 
 import { StorageApiClient } from "./lib/api";
 
+import { BelfJwtService } from "src/belf-jwt/belf-jwt.service";
+
 @Injectable()
 export class StorageService {
   private readonly storageApiClient: StorageApiClient;
+  private readonly belfJwtService: BelfJwtService;
 
-  constructor(storageApiClient: StorageApiClient) {
+  constructor(storageApiClient: StorageApiClient, belfJwtService: BelfJwtService) {
     this.storageApiClient = storageApiClient;
+    this.belfJwtService = belfJwtService;
   }
 
   async getServiceName() {
@@ -59,11 +63,12 @@ export class StorageService {
     return apiClientResult;
   }
 
-  async uploadFile(file: any): Promise<string> {
+  async uploadFile(headers: Record<string, string>, file: any): Promise<string> {
     let apiClientResult: string;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
 
     try {
-      apiClientResult = await this.storageApiClient.uploadFile(file);
+      apiClientResult = await this.storageApiClient.uploadFile(file, userId);
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
# 변경 내역

1. storage service내 파일 upload 기능 사용시 JWT에서 userId 디코딩해 storage service 호출하는 기능 추가

# 변경 사유

1. userId값을 client가 변조했는지 확인하기 위해 OAuth 서비스를 사용한 검증 로직이 필요

# 테스트 방법

1. storage service가 k8s에서 런칭되면 해당 기능을 테스트 해봅니다.