### PR TITLE
File 삭제하는 API endpoint 추가

### DIFF
--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -28,7 +28,8 @@ export class MiddlewareModule implements NestModule {
         { path: "/todo/work-todos", method: RequestMethod.DELETE },
         { path: "/todo/work-dones", method: RequestMethod.POST },
         { path: "/todo/work-dones", method: RequestMethod.DELETE },
-        { path: "/storage/upload", method: RequestMethod.POST }
+        { path: "/storage/upload", method: RequestMethod.POST },
+        { path: "/storage/delete", method: RequestMethod.DELETE }
       );
   }
 }

--- a/src/storage/lib/api.ts
+++ b/src/storage/lib/api.ts
@@ -86,6 +86,22 @@ export class StorageApiClient {
     return serviceResult;
   }
 
+  async deleteFile(userId: number, fileId: string): Promise<any> {
+    let serviceResult: any;
+
+    let querystring = userId ? `?userId=${userId}` : "";
+    querystring = fileId ? querystring + `&fileId=${fileId}` : querystring;
+
+    try {
+      const res = await this.httpService.delete("/api/v1/delete" + querystring).toPromise();
+      serviceResult = res.data;
+    } catch (error) {
+      throw error;
+    }
+
+    return serviceResult;
+  }
+
   getFileURL(id: string): string {
     const baseURL = this.httpService.axiosRef.defaults.baseURL;
     return baseURL + "/api/v1/download/" + id;

--- a/src/storage/storage.controller.ts
+++ b/src/storage/storage.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, UploadedFile, UseInterceptors, Param, HttpException, Headers } from "@nestjs/common";
+import { Controller, Get, Post, UploadedFile, UseInterceptors, Param, HttpException, Headers, Delete, Query } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
 
 import { StorageService } from "./storage.service";
@@ -84,6 +84,22 @@ export class StorageController {
 
     try {
       serviceResult = await this.appService.uploadFile(headers, file);
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      throw new HttpException(message, httpStatusCode);
+    }
+
+    return serviceResult;
+  }
+
+  @Delete("delete")
+  async deleteFile(@Headers() headers: Record<string, string>, @Query("fileId") fileId: string): Promise<string> {
+    let serviceResult: string;
+
+    try {
+      serviceResult = await this.appService.deleteFile(headers, fileId);
     } catch (error) {
       const httpStatusCode = getErrorHttpStatusCode(error);
       const message = getErrorMessage(error);

--- a/src/storage/storage.http
+++ b/src/storage/storage.http
@@ -20,6 +20,11 @@ GET {{Host}}/{{Router}}/file/base64/{{FileId}}
 
 ### File upload
 POST {{Host}}/{{Router}}/upload
+authorization: 
+
+### File delete
+DELETE {{Host}}/{{Router}}/delete?fileId={{FileId}}
+authorization: 
 
 ### File 정보 가져오기
 GET {{Host}}/{{Router}}/info/{{FileId}}

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -76,6 +76,19 @@ export class StorageService {
     return apiClientResult;
   }
 
+  async deleteFile(headers: Record<string, string>, fileId: string): Promise<string> {
+    let apiClientResult: string;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
+
+    try {
+      apiClientResult = await this.storageApiClient.deleteFile(userId, fileId);
+    } catch (error) {
+      throw error;
+    }
+
+    return apiClientResult;
+  }
+
   getFileURL(id: string) {
     return this.storageApiClient.getFileURL(id);
   }


### PR DESCRIPTION
# 변경 내역

1. storage service내 파일을 삭제할 수 있는 API endpoint 추가

# 변경 사유

1. @parkgang 님의 요청으로 파일 삭제기능 추가후 API Gateway 서비스에서 해당 기능 동작해야 할 필요성 존재

# 테스트 방법

1. storage service를 k8s에 구축후 API endpoint를 호출한다.