### PR TITLE
로컬 개발용 docker파일 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# 로컬 테스트용 파일입니다.
+version: "3.8"
+services:
+  api-service:
+    build:
+      context: "./"
+      dockerfile: Dockerfile
+    image: "jp3pe/belf-kr/api-service"
+    container_name: "belf-api-service"
+    environment:
+      - SERVER_PORT=3000
+      - SERVER_PORT_OAUTH=3001
+      - SERVER_PORT_MOCK=3002
+      - SERVER_PORT_TODO=3003
+      - SERVER_PORT_STORAGE=3004
+    ports:
+      - "3000:3000"
+    command: ["npm", "run", "start:docker"]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "cross-env NODE_ENV=development nest start --watch",
+    "start:docker": "cross-env NODE_ENV=docker node dist/src/main",
     "start:debug": "cross-env NODE_ENV=development nest start --debug --watch",
     "start:prod": "cross-env NODE_ENV=production node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/src/common/lib/service.ts
+++ b/src/common/lib/service.ts
@@ -19,6 +19,9 @@ export function K8sServiceDNS(svc: string, port: number): string {
       // TODO: 해당 주소가 사용되고 있는 주소인지 확인하는 방어코드 필요
       url = `http://localhost:${port}`;
       break;
+    case "docker":
+      url = `http://host.docker.internal:${port}`;
+      break;
     default:
       if (!ns) {
         throw new Error(`STAGES 환경 변수 값이 지정되지 않았습니다.`);


### PR DESCRIPTION
# 변경 내역

1. 즉시 개발 환경에서 테스트를 할 수 있는 docker-compose.yml 파일 및 관련 기능 추가

# 변경 사유

1. 로컬 환경에서 빠른 시작용 docker환경이 필요해짐

# 테스트 방법

1. 기존 구현한 기능이 동작하는지 확인합니다.