### PR TITLE
work-todo 조회시 courseId 가져올 수 있게 타입코드 수정

### DIFF
--- a/src/common/type/work-todo-get.interface.ts
+++ b/src/common/type/work-todo-get.interface.ts
@@ -3,4 +3,6 @@ import { WorkTodoType } from "./work-todo.type";
 export interface WorkTodoGetInterface extends WorkTodoType {
   courseTitle: string;
   color: string;
+  repeatedDaysOfTheWeek: number[];
+  courseId: number;
 }


### PR DESCRIPTION
# 변경 내역

1. work-todo 조회시 반환되는 json 내부의 courseId 값이 포함되도록 코드 수정

# 변경 사유

1. @algo2000 님의 기능 요청

# 테스트 방법

1. QA배포 완료후 work-todo 조회시 courseId값이 포함되어 출력되는지 확인합니다.