### PR TITLE
JWT 입력값 형식 변경

### DIFF
--- a/src/belf-jwt/belf-jwt.service.ts
+++ b/src/belf-jwt/belf-jwt.service.ts
@@ -6,7 +6,7 @@ export class BelfJwtService {
   constructor(private readonly jwtService: JwtService) {}
 
   getUserId(jwtInput: string) {
-    const decodedJwt = this.jwtService.decode(jwtInput);
+    const decodedJwt = this.jwtService.decode(jwtInput.substring(7));
     const userId = decodedJwt["user_id"] ?? undefined;
 
     return parseInt(userId);

--- a/src/middleware/oauth.middleware.ts
+++ b/src/middleware/oauth.middleware.ts
@@ -14,14 +14,14 @@ export class OauthMiddleware implements NestMiddleware {
     if (jwtInput) {
       requestConfig = {
         headers: {
-          Authorization: `Bearer ${jwtInput}`,
+          Authorization: `${jwtInput}`,
         },
       };
     }
 
     try {
       if (!requestConfig) {
-        throw new HttpException({ data: "검증을 위한 JWT 값이 입력되지 않았습니다.", status: HttpStatus.BAD_REQUEST }, HttpStatus.BAD_REQUEST);
+        throw new HttpException({ data: "검증을 위한 JWT 값이 입력되지 않았습니다.", status: HttpStatus.UNAUTHORIZED }, HttpStatus.UNAUTHORIZED);
       }
 
       await this.httpService.get("/api/users/token/valid", requestConfig).toPromise();

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -36,7 +36,7 @@ GET {{Host}}/{{Router}}/courses?userId=
 
 ### course 생성
 POST {{Host}}/{{Router}}/courses
-authorization: 
+authorization: Bearer 
 Content-Type: application/json
 
 {
@@ -55,11 +55,11 @@ Content-Type: application/json
 
 ### course 삭제
 DELETE {{Host}}/{{Router}}/courses/1
-authorization: 
+authorization: Bearer 
 
 ### work_todo 추가(필수)
 POST {{Host}}/{{Router}}/work-todos
-authorization: 
+authorization: Bearer 
 Content-Type: application/json
 
 {
@@ -70,7 +70,7 @@ Content-Type: application/json
 
 ### work_todo 추가(선택)
 POST {{Host}}/{{Router}}/work-todos
-authorization: 
+authorization: Bearer 
 Content-Type: application/json
 
 {
@@ -93,11 +93,11 @@ GET {{Host}}/{{Router}}/work-todos/1
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/work-todos/1
-authorization: 
+authorization: Bearer 
 
 ### work_done 추가
 POST {{Host}}/{{Router}}/work-dones
-authorization: 
+authorization: Bearer 
 Content-Type: application/json
 
 {
@@ -117,4 +117,4 @@ GET {{Host}}/{{Router}}/work-dones
 
 ### work_done 삭제
 DELETE {{Host}}/{{Router}}/work-dones/1
-authorization: 
+authorization: Bearer 


### PR DESCRIPTION
# 변경 내역

1. JWT 입력시 HTTP Header 값의 authorization key에 대한 value로 Bearer 문자열을 입력하도록 변경

# 변경 사유

1. 표준에 맞추기 위함

# 테스트 방법

1. API를 통해 Todo service 호출시 Bearer {JWT} 형식이 작동되는지 확인한다.