### PR TITLE
정상적으로 한일을 가져올 수 있도록 쿼리스트링 로직 픽스

### DIFF
--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -217,8 +217,8 @@ export class TodoApiClient {
       const res = await this.httpService
         .get("/work-dones", {
           params: {
-            userId: userId.toString(),
-            courseId: courseId.toString(),
+            userId: userId?.toString(),
+            courseId: courseId?.toString(),
           },
         })
         .toPromise();

--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -212,21 +212,20 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async getWorkDoneByConditions(userId: number, courseId?: number, activeDate?: Date, maximumActiveDate?: Date): Promise<AxiosResponse<any>> {
-    let serviceResult: any;
-
+  async getWorkDoneByConditions(userId?: number, courseId?: number): Promise<AxiosResponse<any>> {
     try {
-      let querystring = userId ? `?userId=${userId}` : "";
-      querystring = courseId ? querystring + `&courseId=${courseId}` : querystring;
-      querystring = courseId ? querystring + `&activeDate=${activeDate}` : querystring;
-      querystring = courseId ? querystring + `&maximumActiveDate=${maximumActiveDate}` : querystring;
-
-      serviceResult = await this.httpService.get("/work-dones" + querystring).toPromise();
+      const res = await this.httpService
+        .get("/work-dones", {
+          params: {
+            userId: userId.toString(),
+            courseId: courseId.toString(),
+          },
+        })
+        .toPromise();
+      return res;
     } catch (error) {
       throw error;
     }
-
-    return serviceResult;
   }
 
   async getWorkDone(id: number): Promise<AxiosResponse<any>> {


### PR DESCRIPTION
# Feature

1. 이전 코드에서는 `userId` 가 없다면 정상적으로 쿼리스트링이 조립되지 않는 문제가 있어 한일을 정상적으로 쿼리하지 못하였습니다.
2. `userId`와 관계 없이 정상적으로 쿼리할 수 있도록 수정하였습니다.