### PR TITLE
버전 정보 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# nodeenv
+env-14.16.1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
   "configurations": [
     {
-      "command": "npm i && npm run prebuild && npm run start:dev",
+      "command": "source ./env-14.16.1/bin/activate && npm i && npm run prebuild && npm run start:dev",
       "name": "Nestjs start",
       "request": "launch",
       "type": "node-terminal"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ client, service 간의 HTTP 요청 및 응답을 중계합니다.
    1. Todo service의 HTTP listen port
    1. Storage service의 HTTP listen port
 1. 각 service에 HTTP 요청을 보내서 service가 실행 되고 있음을 확인합니다.
+1. `nodeenv --node=14.16.1 env-14.16.1` 명령을 실행해서 프로젝트 디렉토리 내부에 `node`, `npm` 실행 환경을 생성합니다.
 1. VSCode 디버그 창 내부에 있는 NestJS start 버튼을 눌러 시작합니다.
 
 ### QA/production 환경

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api-gateway",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -624,9 +624,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-      "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
     },
     "@hapi/topo": {
       "version": "5.1.0",
@@ -1184,9 +1184,9 @@
       }
     },
     "@sideway/address": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
-      "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
+      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -1413,9 +1413,9 @@
       }
     },
     "@types/node": {
-      "version": "14.17.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.34.tgz",
-      "integrity": "sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg=="
+      "version": "14.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -4976,13 +4976,13 @@
       }
     },
     "joi": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
-      "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.5.0.tgz",
+      "integrity": "sha512-R7hR50COp7StzLnDi4ywOXHrBrgNXuUUfJWIR5lPY5Bm/pOD3jZaTwpluUXVLRWcoWZxkrHBBJ5hLxgnlehbdw==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.0",
+        "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-gateway",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "",
   "author": "",
   "private": true,
@@ -30,7 +30,7 @@
     "axios": "^0.22.0",
     "cross-env": "^7.0.3",
     "form-data": "^4.0.0",
-    "joi": "^17.4.0",
+    "joi": "^17.5.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^6.6.6"
@@ -42,7 +42,7 @@
     "@types/express": "^4.17.11",
     "@types/jest": "^26.0.22",
     "@types/multer": "^1.4.7",
-    "@types/node": "^14.17.32",
+    "@types/node": "^14.18.0",
     "@types/supertest": "^2.0.10",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",


### PR DESCRIPTION
# 변경 내역

1. 버전 업데이트
2. npm 패키지 업데이트
3. vscode 사용시 nodeenv 사용하는 명령어 추가

# 변경 사유

1. 금주 출시를 위함
2. 개발 환경에서 여러개의 node 환경 사용의 편의성을 위함

# 테스트 방법

1. QA 배포후 버전 정보가 0.9.0이 응답되는지 확인합니다.
2. 로컬 개발 환경을 통해 구동시 nodeenv 설정이 자동 실행되는지 확인합니다.