### PR TITLE
API 코드 내 querystring 처리 로직 수정

### DIFF
--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -108,10 +108,15 @@ export class TodoApiClient {
 
   async getCoursesByConditions(userId?: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
-    const querystring = userId ? `?userId=${userId}` : "";
 
     try {
-      serviceResult = await this.httpService.get("/courses" + querystring).toPromise();
+      serviceResult = await this.httpService
+        .get("/courses", {
+          params: {
+            userId: userId?.toString(),
+          },
+        })
+        .toPromise();
     } catch (error) {
       throw error;
     }
@@ -133,10 +138,15 @@ export class TodoApiClient {
 
   async deleteCourse(userId: number, id: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
-    const querystring = userId ? `?userId=${userId}` : "";
 
     try {
-      serviceResult = await this.httpService.delete("/courses/" + id + querystring).toPromise();
+      serviceResult = await this.httpService
+        .delete("/courses/" + id, {
+          params: {
+            userId: userId?.toString(),
+          },
+        })
+        .toPromise();
     } catch (error) {
       throw error;
     }
@@ -161,12 +171,16 @@ export class TodoApiClient {
     let serviceResult: any;
 
     try {
-      let querystring = userId ? `?userId=${userId}` : "";
-      querystring = courseId ? querystring + `&courseId=${courseId}` : querystring;
-      querystring = courseId ? querystring + `&activeDate=${activeDate}` : querystring;
-      querystring = courseId ? querystring + `&maximumActiveDate=${maximumActiveDate}` : querystring;
-
-      serviceResult = await this.httpService.get("/work-todos" + querystring).toPromise();
+      serviceResult = await this.httpService
+        .get("/work-todos", {
+          params: {
+            userId: userId?.toString(),
+            courseId: courseId?.toString(),
+            activeDate: activeDate?.toString(),
+            maximumActiveDate: maximumActiveDate?.toString(),
+          },
+        })
+        .toPromise();
     } catch (error) {
       throw error;
     }
@@ -188,10 +202,15 @@ export class TodoApiClient {
 
   async deleteWorkTodo(userId: number, id: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
-    const querystring = userId ? `?userId=${userId}` : "";
 
     try {
-      serviceResult = await this.httpService.delete("/work-todos/" + id + querystring).toPromise();
+      serviceResult = await this.httpService
+        .delete("/work-todos/" + id, {
+          params: {
+            userId: userId?.toString(),
+          },
+        })
+        .toPromise();
     } catch (error) {
       throw error;
     }
@@ -242,10 +261,15 @@ export class TodoApiClient {
 
   async deleteWorkDone(userId: number, id: number): Promise<AxiosResponse<any>> {
     let serviceResult: any;
-    const querystring = userId ? `?userId=${userId}` : "";
 
     try {
-      serviceResult = await this.httpService.delete("/work-dones/" + id + querystring).toPromise();
+      serviceResult = await this.httpService
+        .delete("/work-dones/" + id, {
+          params: {
+            userId: userId?.toString(),
+          },
+        })
+        .toPromise();
     } catch (error) {
       throw error;
     }

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -1,5 +1,6 @@
 @Host = http://localhost:3000
 # @Host = https://api-gateway.qa.belf.xyz
+@JWT = Bearer 
 @Router = todo
 
 ### Get service name
@@ -36,7 +37,7 @@ GET {{Host}}/{{Router}}/courses?userId=
 
 ### course 생성
 POST {{Host}}/{{Router}}/courses
-authorization: Bearer 
+authorization: {{JWT}}
 Content-Type: application/json
 
 {
@@ -50,12 +51,14 @@ Content-Type: application/json
         {
             "value": "하하하"
         }
-    ]
+    ],
+    "startDate": "2021-11-05",
+    "endDate": "2021-11-05"
 }
 
 ### course import
 POST {{Host}}/{{Router}}/courses
-authorization: Bearer 
+authorization: {{JWT}}
 Content-Type: application/json
 
 {
@@ -66,11 +69,11 @@ Content-Type: application/json
 
 ### course 삭제
 DELETE {{Host}}/{{Router}}/courses/1
-authorization: Bearer 
+authorization: {{JWT}}
 
 ### work_todo 추가(필수)
 POST {{Host}}/{{Router}}/work-todos
-authorization: Bearer 
+authorization: {{JWT}} 
 Content-Type: application/json
 
 {
@@ -81,7 +84,7 @@ Content-Type: application/json
 
 ### work_todo 추가(선택)
 POST {{Host}}/{{Router}}/work-todos
-authorization: Bearer 
+authorization: {{JWT}}
 Content-Type: application/json
 
 {
@@ -93,9 +96,6 @@ Content-Type: application/json
     "explanation": "나만의 할 일 설명1"
 }
 
-### work_todo 전체 리스트 가져오기
-GET {{Host}}/{{Router}}/work-todos
-
 ### work_todo 조건에 알맞은 리스트 가져오기
 GET {{Host}}/{{Router}}/work-todos?userId=&courseId=&activeDate=&maximumActiveDate=
 
@@ -104,11 +104,11 @@ GET {{Host}}/{{Router}}/work-todos/1
 
 ### work_todo 삭제
 DELETE {{Host}}/{{Router}}/work-todos/1
-authorization: Bearer 
+authorization: {{JWT}} 
 
 ### work_done 추가
 POST {{Host}}/{{Router}}/work-dones
-authorization: Bearer 
+authorization: {{JWT}} 
 Content-Type: application/json
 
 {
@@ -129,4 +129,4 @@ GET {{Host}}/{{Router}}/work-dones
 
 ### work_done 삭제
 DELETE {{Host}}/{{Router}}/work-dones/1
-authorization: Bearer 
+authorization: {{JWT}} 


### PR DESCRIPTION
# 변경 내역

1. api.ts 파일 내부의 todo 서비스를 호출하기 위한 querystring 추가 로직을 전부 axios에서 제공하는 형식으로 변경
2. http 파일 내부의 JWT 토큰 입력 방볍 변수로 변경

# 변경 사유

1. 기존 개발한 querystring 처리 로직은 에러가 나는 경우 querystring이 전무 쓸모 없어지는 경우가 work-todo 호출시 발생
2. 매번 동일한 JWT를 테스트시 입력하는게 귀찮음

# 테스트 방법

1. 코드 변경후 querystring에 대한 처리가 QA 서버에서 정상 동작하는지 확인한다.