### PR TITLE
course 제목 검색 기능 API endpoint 추가

### DIFF
--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -94,6 +94,24 @@ export class TodoApiClient {
   }
 
   // Course
+  async searchCourse(keyword: string): Promise<AxiosResponse<any>> {
+    let serviceResult: any;
+
+    try {
+      serviceResult = await this.httpService
+        .get("/courses/search", {
+          params: {
+            keyword: keyword.toString(),
+          },
+        })
+        .toPromise();
+    } catch (error) {
+      throw error;
+    }
+
+    return serviceResult;
+  }
+
   async createCourse(coursesInput: CourseType): Promise<AxiosResponse<any>> {
     let serviceResult: any;
 

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -121,6 +121,23 @@ export class TodoController {
     return serviceResult;
   }
 
+  @Get("courses/search")
+  async searchCourse(@Query("keyword") keyword: string) {
+    let serviceResult: any;
+
+    try {
+      const result: AxiosResponse<any> = await this.appService.searchCourse(keyword);
+      serviceResult = result.data;
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      throw new HttpException(message, httpStatusCode);
+    }
+
+    return serviceResult;
+  }
+
   @Post("courses")
   async createCourse(@Headers() headers: Record<string, string>, @Body() coursePostInput: CoursePostInterface) {
     let serviceResult: any;

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -26,6 +26,9 @@ Content-Type: application/json
     "id": "#FFFFFF"
 }
 
+### course title 검색
+GET {{Host}}/{{Router}}/courses/search?keyword=
+
 ### course 정보 전체 조회
 GET {{Host}}/{{Router}}/courses
 

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -119,6 +119,18 @@ export class TodoService {
     return apiClientResult;
   }
 
+  async searchCourse(keyword: string) {
+    let apiClientResult: any;
+
+    try {
+      apiClientResult = await this.todoApiClient.searchCourse(keyword);
+    } catch (error) {
+      throw error;
+    }
+
+    return apiClientResult;
+  }
+
   async createCourse(courseInput: CourseType, headers: Record<string, string>) {
     let apiClientResult: any;
     courseInput.userId = this.belfJwtService.getUserId(headers["authorization"]);


### PR DESCRIPTION
# 변경 내역

1. course의 제목을 키워드 검색할 수 있는 API endpoint 추가

# 변경 사유

1. @algo2000 님의 요청

# 테스트 방법

1. 생성된 HTTP endpoint에 HTTP GET 요청을 보내 키워드에 해당되는 데이터가 반환되는지 확인한다.