### PR TITLE
import된 course만 가져오는 API endpoint 추가

### DIFF
--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -124,7 +124,7 @@ export class TodoApiClient {
     return serviceResult;
   }
 
-  async getCoursesByConditions(userId?: number): Promise<AxiosResponse<any>> {
+  async getCoursesByConditions(userId?: number, courseId?: number, belfOnly?: boolean): Promise<AxiosResponse<any>> {
     let serviceResult: any;
 
     try {
@@ -132,6 +132,8 @@ export class TodoApiClient {
         .get("/courses", {
           params: {
             userId: userId?.toString(),
+            courseId: courseId?.toString(),
+            belfOnly: belfOnly?.toString(),
           },
         })
         .toPromise();

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -156,11 +156,11 @@ export class TodoController {
   }
 
   @Get("courses")
-  async getCoursesByConditions(@Query("userId") userId?: number) {
+  async getCoursesByConditions(@Query("userId") userId?: number, @Query("courseId") courseId?: number, @Query("belfOnly") belfOnly?: boolean) {
     let serviceResult: CourseGetInterface[];
 
     try {
-      const result: AxiosResponse<any> = await this.appService.getCoursesByConditions(userId);
+      const result: AxiosResponse<any> = await this.appService.getCoursesByConditions(userId, courseId, belfOnly);
 
       serviceResult = result.data;
     } catch (error) {

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -36,7 +36,7 @@ GET {{Host}}/{{Router}}/courses
 GET {{Host}}/{{Router}}/courses/1
 
 ### course 조건으로 조회
-GET {{Host}}/{{Router}}/courses?userId=
+GET {{Host}}/{{Router}}/courses?userId=&belfOnly=
 
 ### course 생성
 POST {{Host}}/{{Router}}/courses

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -36,7 +36,7 @@ GET {{Host}}/{{Router}}/courses
 GET {{Host}}/{{Router}}/courses/1
 
 ### course 조건으로 조회
-GET {{Host}}/{{Router}}/courses?userId=&belfOnly=
+GET {{Host}}/{{Router}}/courses?userId=&belfOnly=&courseId=
 
 ### course 생성
 POST {{Host}}/{{Router}}/courses

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -144,11 +144,11 @@ export class TodoService {
     return apiClientResult;
   }
 
-  async getCoursesByConditions(userId?: number) {
+  async getCoursesByConditions(userId?: number, courseId?: number, belfOnly?: boolean) {
     let apiClientResult: any;
 
     try {
-      apiClientResult = await this.todoApiClient.getCoursesByConditions(userId);
+      apiClientResult = await this.todoApiClient.getCoursesByConditions(userId, courseId, belfOnly);
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
# 변경 내역

1. import된 course만 가져오는 API endpoint 추가

# 변경 사유

1. @algo2000 님의 요청

# 테스트 방법

1. course를 조건에 따라 가져오는 API endpoint를 통해서 import된 코스만 가져오는 querystring을 추가한 다음 응답이 기대한 것과 동일한지 확인한다.