### PR TITLE
deprecated된 kubectl 명령어 변경, slack slack notification 메시지 표시되도록

### DIFF
--- a/.github/workflows/aks-prod-deploy.yaml
+++ b/.github/workflows/aks-prod-deploy.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: create namespace
         run: |
-          kubectl create namespace ${{ env.NAMESPACE }} --dry-run -o json | kubectl apply -f -
+          kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o json | kubectl apply -f -
 
       - name: aks apply object
         uses: Azure/k8s-deploy@v1.4
@@ -64,3 +64,4 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: ${{ github.repository }}가 ${{ env.NAMESPACE }} 환경에 배포되었습니다 🚀

--- a/.github/workflows/aks-qa-deploy.yaml
+++ b/.github/workflows/aks-qa-deploy.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: create namespace
         run: |
-          kubectl create namespace ${{ env.NAMESPACE }} --dry-run -o json | kubectl apply -f -
+          kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o json | kubectl apply -f -
 
       - name: aks apply object
         uses: Azure/k8s-deploy@v1.4
@@ -61,3 +61,4 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: ${{ github.repository }}가 ${{ env.NAMESPACE }} 환경에 배포되었습니다 🚀

--- a/.github/workflows/aks-test-deploy.yaml
+++ b/.github/workflows/aks-test-deploy.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: create namespace
         run: |
-          kubectl create namespace ${{ env.NAMESPACE }} --dry-run -o json | kubectl apply -f -
+          kubectl create namespace ${{ env.NAMESPACE }} --dry-run=client -o json | kubectl apply -f -
 
       - name: aks apply object
         uses: Azure/k8s-deploy@v1.4
@@ -63,3 +63,4 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_MESSAGE: ${{ github.repository }}가 ${{ env.NAMESPACE }} 환경에 배포되었습니다 🚀

--- a/package-lock.json
+++ b/package-lock.json
@@ -6028,9 +6028,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.0.tgz",
-      "integrity": "sha512-FM/zAKgWTxj40rH03VxzIPdXmj39SwSjwG0heUcNFwI+EMZJnY93yAiKXM3dObIKAM5TA88werc8T/EwhB45eg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -7799,9 +7799,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.3.tgz",
+      "integrity": "sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==",
       "dev": true
     },
     "union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api-gateway",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-gateway",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "description": "",
   "author": "",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -50,13 +50,13 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
-    "prettier": "^2.5.0",
+    "prettier": "^2.5.1",
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.4",
     "ts-loader": "^8.0.18",
     "ts-node": "^9.1.1",
     "tsconfig-paths": "^3.12.0",
-    "typescript": "^4.4.4"
+    "typescript": "^4.5.3"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -25,8 +25,8 @@ export class AppController {
     return this.appService.getVersion();
   }
 
-  @Get("env")
-  getEnv(): NodeJS.ProcessEnv {
-    return this.appService.getEnv();
-  }
+  // @Get("env")
+  // getEnv(): NodeJS.ProcessEnv {
+  //   return this.appService.getEnv();
+  // }
 }


### PR DESCRIPTION
# 변경 내역

1. deprecated된 kubectl 명령어로 인하여 ci/cd가 오류가 발생하는 것을 해결
2. ci/cd 완료시 어떤 서비스가 어떤 환경으로 배포되었는지 알 수 있도록 개선
3. 환경 변수를 가져오는 API endpoint 삭제
4. npm 패키지 버전 정보 업데이트
5. 버전 정보 업데이트

# 변경 사유

1. 메이저 버전의 릴리즈를 위함
2. 배포 불가 문제 수정 필요

# 테스트 방법

1. QA 배포 후 slack에 관련 알림이 수신되는지 확인한다.
2. 버전 정보가 1.0.0으로 수신되는지 확인한다.
3. 환경 변수를 가져오는 API endpoint가 동작하지 않는지 확인한다.