### PR TITLE
유저 탈퇴시 데이터 삭제 API endpoint 추가

### DIFF
--- a/src/middleware/middleware.module.ts
+++ b/src/middleware/middleware.module.ts
@@ -27,7 +27,8 @@ export class MiddlewareModule implements NestModule {
         { path: "/todo/work-todos", method: RequestMethod.POST },
         { path: "/todo/work-todos", method: RequestMethod.DELETE },
         { path: "/todo/work-dones", method: RequestMethod.POST },
-        { path: "/todo/work-dones", method: RequestMethod.DELETE }
+        { path: "/todo/work-dones", method: RequestMethod.DELETE },
+        { path: "/todo/users", method: RequestMethod.DELETE }
       );
   }
 }

--- a/src/todo/lib/api.ts
+++ b/src/todo/lib/api.ts
@@ -296,4 +296,16 @@ export class TodoApiClient {
 
     return serviceResult;
   }
+
+  async withdrawarUser(userId: number): Promise<AxiosResponse<any>> {
+    let serviceResult: any;
+
+    try {
+      serviceResult = await this.httpService.delete("/users/" + userId).toPromise();
+    } catch (error) {
+      throw error;
+    }
+
+    return serviceResult;
+  }
 }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -351,4 +351,21 @@ export class TodoController {
 
     return serviceResult;
   }
+
+  @Delete("users/:userId")
+  async withdrawarUser(@Headers() headers: Record<string, string>) {
+    let serviceResult: any;
+
+    try {
+      const result: AxiosResponse<any> = await this.appService.withdrawarUser(headers);
+      serviceResult = result.data;
+    } catch (error) {
+      const httpStatusCode = getErrorHttpStatusCode(error);
+      const message = getErrorMessage(error);
+
+      throw new HttpException(message, httpStatusCode);
+    }
+
+    return serviceResult;
+  }
 }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -352,7 +352,7 @@ export class TodoController {
     return serviceResult;
   }
 
-  @Delete("users/:userId")
+  @Delete("users")
   async withdrawarUser(@Headers() headers: Record<string, string>) {
     let serviceResult: any;
 

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -135,4 +135,5 @@ DELETE {{Host}}/{{Router}}/work-dones/1
 authorization: {{JWT}} 
 
 ### 회원 탈퇴
-DELETE {{Host}}/{{Router}}/users/1
+DELETE {{Host}}/{{Router}}/users
+authorization: {{JWT}} 

--- a/src/todo/todo.http
+++ b/src/todo/todo.http
@@ -133,3 +133,6 @@ GET {{Host}}/{{Router}}/work-dones
 ### work_done 삭제
 DELETE {{Host}}/{{Router}}/work-dones/1
 authorization: {{JWT}} 
+
+### 회원 탈퇴
+DELETE {{Host}}/{{Router}}/users/1

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -282,4 +282,17 @@ export class TodoService {
 
     return apiClientResult;
   }
+
+  async withdrawarUser(headers: Record<string, string>) {
+    let apiClientResult: any;
+    const userId = this.belfJwtService.getUserId(headers["authorization"]);
+
+    try {
+      apiClientResult = await this.todoApiClient.withdrawarUser(userId);
+    } catch (error) {
+      throw error;
+    }
+
+    return apiClientResult;
+  }
 }


### PR DESCRIPTION
# 변경 내역

1. 유저 탈퇴 시 관련 데이터 삭제를 위한 API endpoint 추가

# 변경 사유

1. 유저 탈퇴시 한국인터넷진흥원의 기능 구현 안내서에 따라 관련 데이터를 파기 처리해야 할 필요성 존재

# 테스트 방법

1. 유저의 데이터를 삭제하는 API를 호출한 다음 관련 데이터가 삭제되는지 확인한다.